### PR TITLE
Update speed-sensitive-volume.sh

### DIFF
--- a/freedomev/apps-available/SpeedSensitiveVolume/speed-sensitive-volume.sh
+++ b/freedomev/apps-available/SpeedSensitiveVolume/speed-sensitive-volume.sh
@@ -11,10 +11,10 @@ VOLUME_INCREMENT=1665
 # ------------
 
 get_volume_int() {
-  lv GUI_audioVolume | awk -F\" '{ printf "%d", $2 * 10000 }'
+  /usr/local/bin/lv GUI_audioVolume | awk -F\" '{ printf "%d", $2 * 10000 }'
 }
 get_speed_int() {
-  lv VAPI_vehicleSpeed | awk -F\" '{ printf "%d", $2 }'
+  /usr/local/bin/lv VAPI_vehicleSpeed | awk -F\" '{ printf "%d", $2 }'
 }
 
 INIT_VOLUME=$(get_volume_int)
@@ -40,12 +40,12 @@ while true; do
       if (( NEW_VOLUME <= 0 )); then
         NEW_VOLUME=$VOLUME_INCREMENT
       fi
-      sdv GUI_audioVolume $(echo $NEW_VOLUME | awk '{printf "%.4f", $1 / 10000}')
+      /usr/local/bin/sdv GUI_audioVolume $(echo $NEW_VOLUME | awk '{printf "%.4f", $1 / 10000}')
       PREV_VOLUME=$(get_volume_int)
       PREV_SPEED=$CURRENT_SPEED
     fi
   fi
-  if (( CURRENT_SPEED == 0 )) && [[ $(lv VAPI_driverPresent) != '"true"' ]]; then
+  if (( CURRENT_SPEED == 0 )) && [[ $(/usr/local/bin/lv VAPI_driverPresent) != '"true"' ]]; then
     /bin/sleep 60
   else
     /bin/sleep 1.5


### PR DESCRIPTION
- optimized sleep times - more responsive volume adjustment shouldn't increase overall car api calls by much, due to additional if clauses
- added config value for speed steps (now 8 mph instead of 10 mph) and reduced volume increment to smoothen things out
- added config value for minimum speed at which volume control will start
- added speed diff condition to avoid corner cases where volume could constantly jump between two values
- simplified value conversions and getting/setting of data values
- fixed volume 0 didn't stay at 0
- removed min volume config (min is one increment above volume level 0 now)
- removed max volume config (sense of this script is to keep volume subjectively at the same level)
- reread volume after adjusting it to accomodate for capping and rounding by mcu